### PR TITLE
`na.rm` is not an argument to `left_join()`

### DIFF
--- a/R/FLs.R
+++ b/R/FLs.R
@@ -92,7 +92,7 @@ Ip <- melt_FLS %>%
    dplyr::summarize(Ip = sum(value, na.rm = TRUE)) 
   
 #Bind Ip and Iu data
-FLspdata <- dplyr::left_join(Iu, Ip, by = "sp_name", na.rm = TRUE)
+FLspdata <- dplyr::left_join(Iu, Ip, by = "sp_name")
  
  #Calculate FLs = Ip * 100 / Iu
  FLspdata$FLs <- (FLspdata$Ip*100) / FLspdata$FCs


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

The join functions now check for typos in `...`, and `na.rm` is a typo. That is not an argument to the join functions.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!